### PR TITLE
Add support for Simulcast

### DIFF
--- a/apps/publisher/millicast-sdk.d.ts
+++ b/apps/publisher/millicast-sdk.d.ts
@@ -30,7 +30,7 @@ declare namespace millicast {
   interface BroadcastOptions {
     mediaStream: MediaStream | MediaStreamTrack[];
     events: Event[];
-    isSimulcastEnabled: boolean;
+    simulcast: boolean;
     codec: string
   }
 

--- a/apps/publisher/src/App.tsx
+++ b/apps/publisher/src/App.tsx
@@ -216,7 +216,7 @@ function App() {
                       {
                         mediaStream,
                         events: ['viewercount'],
-                        isSimulcastEnabled: isSimulcastEnabled,
+                        simulcast: isSimulcastEnabled,
                         codec: codec
                       });
                   }

--- a/apps/publisher/src/hooks/usePublisher.ts
+++ b/apps/publisher/src/hooks/usePublisher.ts
@@ -20,12 +20,11 @@ export interface BroadcastOptions {
     // TODO The app only supports the `viewercount` event right now, and none others. Subsribing to other events
     // will not produce any results. 
     events: Event[],
-    isSimulcastEnabled: boolean,
+    simulcast: boolean,
     codec: string
 }
 
 const usePublisher = (token: string, streamName: string, streamId: string): Publisher => {
-
     const [publisherState, setPublisherState] = useState<PublisherState>("ready");
     const [viewerCount, setViewerCount] = useState(0);
     const [codec, setCodec] = useState<string>("")


### PR DESCRIPTION
Some notes on Simulcast -
* There is no feedback from the SDK if an invalid browser/codec combination is applied
* The director API request payload JWT does not contain simulcast information either
* However, if you use  the Millicast `Logger` and set Log Level to `.DEBUG` you will see that it establishes the connection successfully (or otherwise).

Closes #29 
