### PR TITLE
50 camera and microphone select always jump up after selection action

### DIFF
--- a/apps/publisher/src/App.tsx
+++ b/apps/publisher/src/App.tsx
@@ -18,7 +18,6 @@ import {
   Switch,
   Text,
   VStack,
-  HStack
 } from "@chakra-ui/react";
 import usePublisher from "./hooks/usePublisher";
 import useMediaDevices from "./hooks/useMediaDevices";


### PR DESCRIPTION
The PR fixed two existing issues:
1. devices settings popover  move upper after clicking
2. the popover pushes the screen wider on mobile