### PR TITLE
Fixed issue

### DIFF
--- a/libs/video-view/src/index.tsx
+++ b/libs/video-view/src/index.tsx
@@ -4,7 +4,6 @@ import { Box, HStack, IconButton } from '@chakra-ui/react';
 import { IconFullScreen, IconFullScreenExit, IconInfo } from '@millicast-react/dolbyio-icons';
 import StatisticsInfo from '@millicast-react/statistics-info';
 import type { streamStats } from '@millicast/sdk';
-import { NONAME } from 'dns';
 
 export type VideoViewProps = {
   mirrored?: boolean;


### PR DESCRIPTION
Please see the screenshot of the new button style. The style will consist for both default and hover statuses. Also, the background color is 60% transparent black so it's the same as the `statistics info` background color

<img width="688" alt="Screen Shot 2022-11-03 at 5 31 44 pm" src="https://user-images.githubusercontent.com/15189662/199659721-f96b2157-1115-4ab8-8582-04b15613e941.png">
