### PR TITLE
H.264 and simulcast support

### DIFF
--- a/libs/use-viewer/src/index.ts
+++ b/libs/use-viewer/src/index.ts
@@ -61,7 +61,7 @@ const useViewer = (): Viewer => {
           encodingId: layer.id,
           bitrate: layer.bitrate,
           simulcastIdx: layer.simulcastIdx,
-          spatialLayerId: layer.layers[0]?.spatialLayerId, // H264 doesn't have layers. 
+          spatialLayerId: layer.layers[0]?.spatialLayerId, // H264 doesn't have layers.
           temporalLayerId: layer.layers[0]?.temporalLayerId, // H264 doesn't have layers.
         },
       };


### PR DESCRIPTION
H.264 doesn't have layer information- don't try to find it during simulcast setup

Closes #110 